### PR TITLE
Fix bakfile cleanup task import and pattern matching; update README and add task proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Author: Michael Dearing
 
 A role to restart and cleanup ArcSight Smart Connectors when either deployed as a software instance or on an appliance with SSH access. 
 
-The role will prompt you for user-input so that the connector variable can be dynamic. You can also remove the below line and manually define the variable within your playbook. You can even define the variable with your playbook for looping. (See example.)
+The role uses the `connector` variable (from defaults or playbook vars) so connector targeting can be dynamic. If you want interactive input, uncomment the `set_connector.yml` import shown below. (See examples.)
 > tasks/main.yml
 >> ```yaml
->> - import_tasks: set_connector.yml
+>> # - import_tasks: set_connector.yml
 >> ```
 
 Features
@@ -16,7 +16,7 @@ Features
 - Verify service is fully running before moving to the next connector. 
 - Remove cache files older than 1 day.
 - Remove old agent.properties.bak and agent.wrapper.conf.bak created by ArcMC
-- Remove Threaddump fles.
+- Remove Threaddump files.
 - Remove Heapdump files.
 
 TODO

--- a/TASK_PROPOSALS.md
+++ b/TASK_PROPOSALS.md
@@ -1,0 +1,48 @@
+# Task Proposals from Codebase Review
+
+## 1) Typo fix task
+**Task:** Fix the typo "Threaddump fles" to "Threaddump files" in the README features list.
+
+**Why this matters:** The typo makes documentation look unpolished and can reduce trust in operational instructions.
+
+**Evidence:** `README.md` currently says "Remove Threaddump fles.".
+
+---
+
+## 2) Bug fix task
+**Task:** Fix the broken task import in `tasks/main.yml` by aligning the imported filename with the actual task file (`bakfile_clean.yml`) or renaming the file to match the import.
+
+**Why this matters:** The role currently imports `bakfile_cleanup.yml`, but only `tasks/bakfile_clean.yml` exists. This causes role execution to fail when Ansible tries to load a non-existent task file.
+
+**Evidence:**
+- `tasks/main.yml` imports `bakfile_cleanup.yml`.
+- Repository contains `tasks/bakfile_clean.yml`.
+
+---
+
+## 3) Comment/documentation discrepancy task
+**Task:** Reconcile README behavior documentation with actual role behavior around connector input handling.
+
+**Why this matters:** The README says the role prompts for user input and points to importing `set_connector.yml`, but `tasks/main.yml` has that import commented out and relies on defaults or externally provided vars. This discrepancy can mislead operators.
+
+**Proposed update options:**
+- Update README to describe the current behavior (no prompt by default).
+- Or uncomment/import `set_connector.yml` and document interactive mode as default.
+
+**Evidence:**
+- README describes prompting behavior and references `set_connector.yml` import.
+- `tasks/main.yml` currently comments out `import_tasks: set_connector.yml`.
+
+---
+
+## 4) Test improvement task
+**Task:** Add Molecule/CI coverage for role task loading and a minimal execution path, including a regression assertion for task file imports.
+
+**Why this matters:** There are no automated tests in this repository. A syntax/role-load test would have caught the broken `bakfile_cleanup.yml` import immediately.
+
+**Suggested scope:**
+1. Add a Molecule scenario (or equivalent CI job) that runs:
+   - `ansible-playbook --syntax-check` against an example playbook using the role.
+   - A converge run in a container with mocked connector paths.
+2. Add assertions for idempotence and that cleanup tasks do not fail when target files are absent.
+3. Add a regression check ensuring all `import_tasks` files exist.

--- a/tasks/bakfile_clean.yml
+++ b/tasks/bakfile_clean.yml
@@ -3,8 +3,8 @@
     find:
       paths: "{{ connector_base }}/user/agent/"
       recurse: false
-      use_regex: yes
-      patterns: "^*.bak$"
+      use_regex: no
+      patterns: "*.bak"
       file_type: file
     register: files_to_delete
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - import_tasks: stop.yml
 - import_tasks: agentlock_clean.yml
 - import_tasks: cache_cleanup.yml
-- import_tasks: bakfile_cleanup.yml
+- import_tasks: bakfile_clean.yml
 - import_tasks: threaddump_clean.yml
 - import_tasks: heapdump_clean.yml
 - import_tasks: start.yml


### PR DESCRIPTION
### Motivation
- Correct a broken task import so the role no longer fails when loading cleanup tasks. 
- Fix incorrect file-matching logic for `.bak` cleanup so intended files are found and removed. 
- Clarify README behavior around connector input and correct a documentation typo. 

### Description
- Update `tasks/main.yml` to import the existing `bakfile_clean.yml` instead of the missing `bakfile_cleanup.yml`. 
- Change `tasks/bakfile_clean.yml` to use `use_regex: no` with the glob `"*.bak"` so the `find` task matches `.bak` files correctly. 
- Revise `README.md` wording to state the role uses the `connector` variable and to show the `set_connector.yml` import commented out, and fix the "Threaddump fles" typo. 
- Add `TASK_PROPOSALS.md` listing proposed fixes and test/CI improvements discovered during review. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00075f6988323bc502ed47e5a357a)